### PR TITLE
Added 1.6 Remixed Bundle searching

### DIFF
--- a/Bundles/Bundes1_6/CompBundleData1_6.cs
+++ b/Bundles/Bundes1_6/CompBundleData1_6.cs
@@ -1,0 +1,298 @@
+﻿// Compressed version of BundleData
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using SeedFinding.Bundles;
+
+namespace SeedFinding.Bundles1_6
+{
+    public class CompBundleData
+    {
+        public string Name;
+        public int Index;
+        public BigInteger BaseFlag;
+        public List<List<BigInteger>> Flags;
+        public bool HasRandom = false;
+        public int Pick = -1;
+        public int RequiredItems = -1;
+        public string Reward;
+
+        public CompBundleData(BundleData bundleData)
+        {
+            Name = bundleData.Name;
+            Index = bundleData.Index;
+            Pick = bundleData.Pick;
+            RequiredItems = bundleData.RequiredItems;
+            Reward = bundleData.Reward;
+            Flags = new List<List<BigInteger>>();
+            switch (Name)
+            {
+                case "Spring Foraging":
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.CRAFTS_SPRING_FORAGE_WILD_HORSERADISH,
+                            CompressedFlags.CRAFTS_SPRING_FORAGE_DAFFODIL,
+                            CompressedFlags.CRAFTS_SPRING_FORAGE_LEEK,
+                            CompressedFlags.CRAFTS_SPRING_FORAGE_DANDELION,
+                            CompressedFlags.CRAFTS_SPRING_FORAGE_SPRING_ONION
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Winter Foraging":
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.CRAFTS_WINTER_FORAGE_WINTER_ROOT,
+                            CompressedFlags.CRAFTS_WINTER_FORAGE_CRYSTAL_FRUIT,
+                            CompressedFlags.CRAFTS_WINTER_FORAGE_SNOW_YAM,
+                            CompressedFlags.CRAFTS_WINTER_FORAGE_CROCUS,
+                            CompressedFlags.CRAFTS_WINTER_FORAGE_HOLLY
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Construction":
+                    BaseFlag = CompressedFlags.CRAFTS_CONSTRUCTION;
+                    break;
+                case "Sticky":
+                    BaseFlag = CompressedFlags.CRAFTS_STICKY;
+                    break;
+                case "Forest":
+                    BaseFlag = CompressedFlags.CRAFTS_FOREST;
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.CRAFTS_FOREST_MOSS,
+                            CompressedFlags.CRAFTS_FOREST_FIBER,
+                            CompressedFlags.CRAFTS_FOREST_ACORN,
+                            CompressedFlags.CRAFTS_FOREST_MAPLE_SEED
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Exotic Foraging":
+                    BaseFlag = CompressedFlags.CRAFTS_EXOTIC;
+                    break;
+                case "Wild Medicine":
+                    BaseFlag = CompressedFlags.CRAFTS_WILD_MEDICINE;
+                    break;
+
+                case "Spring Crops":
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.PANTRY_SPRING_CROPS_PARSNIP,
+                            CompressedFlags.PANTRY_SPRING_CROPS_GREEN_BEAN,
+                            CompressedFlags.PANTRY_SPRING_CROPS_CAULIFLOWER,
+                            CompressedFlags.PANTRY_SPRING_CROPS_POTATO,
+                            CompressedFlags.PANTRY_SPRING_CROPS_KALE,
+                            CompressedFlags.PANTRY_SPRING_CROPS_CARROT
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Summer Crops":
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.PANTRY_SUMMER_CROPS_TOMATO,
+                            CompressedFlags.PANTRY_SUMMER_CROPS_HOT_PEPPER,
+                            CompressedFlags.PANTRY_SUMMER_CROPS_BLUEBERRY,
+                            CompressedFlags.PANTRY_SUMMER_CROPS_MELON,
+                            CompressedFlags.PANTRY_SUMMER_CROPS_SUMMER_SQUASH
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Fall Crops":
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.PANTRY_FALL_CROPS_CORN,
+                            CompressedFlags.PANTRY_FALL_CROPS_EGGPLANT,
+                            CompressedFlags.PANTRY_FALL_CROPS_PUMPKIN,
+                            CompressedFlags.PANTRY_FALL_CROPS_YAM,
+                            CompressedFlags.PANTRY_FALL_CROPS_BROCCOLI
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Quality Crops":
+                    BaseFlag = CompressedFlags.PANTRY_QUALITY;
+                    HasRandom = true;
+                    Flags.Add(new List<BigInteger>() { 0 });
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.PANTRY_QUALITY_PUMPKIN,
+                            CompressedFlags.PANTRY_QUALITY_EGGPLANT,
+                            CompressedFlags.PANTRY_QUALITY_YAM
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.PANTRY_QUALITY_MELON,
+                            CompressedFlags.PANTRY_QUALITY_HOT_PEPPER,
+                            CompressedFlags.PANTRY_QUALITY_BLUEBERRY
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.PANTRY_QUALITY_PARSNIP,
+                            CompressedFlags.PANTRY_QUALITY_GREEN_BEAN,
+                            CompressedFlags.PANTRY_QUALITY_CAULIFLOWER,
+                            CompressedFlags.PANTRY_QUALITY_POTATO
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Rare Crops":
+                    BaseFlag = CompressedFlags.PANTRY_RARE;
+                    break;
+                case "Animal":
+                    BaseFlag = CompressedFlags.PANTRY_ANIMAL;
+                    break;
+                case "Fish Farmer's":
+                    BaseFlag = CompressedFlags.PANTRY_FISH_FARMER;
+                    break;
+                case "Garden":
+                    BaseFlag = CompressedFlags.PANTRY_GARDEN;
+                    break;
+                case "Artisan":
+                    BaseFlag = CompressedFlags.PANTRY_ARTISAN;
+                    break;
+                case "Brewer's":
+                    BaseFlag = CompressedFlags.PANTRY_BREWER;
+                    break;
+                case "Specialty Fish":
+                    BaseFlag = CompressedFlags.FISH_SPECIALITY;
+                    break;
+                case "Quality Fish":
+                    BaseFlag = CompressedFlags.FISH_QUALITY;
+                    break;
+                case "Master Fisher's":
+                    BaseFlag = CompressedFlags.FISH_MASTER;
+                    break;
+
+                case "Blacksmith's":
+                    BaseFlag = CompressedFlags.BOILER_BLACKSMITH;
+                    break;
+                case "Geologist's":
+                    BaseFlag = CompressedFlags.BOILER_GEOLOGIST;
+                    break;
+                case "Adventurer's":
+                    BaseFlag = CompressedFlags.BOILER_ADVENTURER;
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BOILER_ADVENTURER_SLIME,
+                            CompressedFlags.BOILER_ADVENTURER_BAT_WING,
+                            CompressedFlags.BOILER_ADVENTURER_SOLAR_ESSENCE,
+                            CompressedFlags.BOILER_ADVENTURER_VOID_ESSENCE,
+                            CompressedFlags.BOILER_ADVENTURER_BONE_FRAGMENTS
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Treasure Hunter's":
+                    BaseFlag = CompressedFlags.BOILER_TREASURE_HUNTER;
+                    break;
+                case "Engineer's":
+                    BaseFlag = CompressedFlags.BOILER_ENGINEER;
+                    break;
+
+                case "Chef's":
+                    BaseFlag = CompressedFlags.BULLETIN_CHEF;
+                    break;
+                case "Dye":
+                    BaseFlag = CompressedFlags.BULLETIN_DYE;
+                    HasRandom = true;
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BULLETIN_DYE_RED_CABBAGE,
+                            CompressedFlags.BULLETIN_DYE_IRIDIUM_BAR
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BULLETIN_DYE_AQUAMARINE,
+                            CompressedFlags.BULLETIN_DYE_BLUEBERRY
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BULLETIN_DYE_DUCK_FEATHER,
+                            CompressedFlags.BULLETIN_DYE_CACTUS_FRUIT
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BULLETIN_DYE_SUNFLOWER,
+                            CompressedFlags.BULLETIN_DYE_STARFRUIT
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BULLETIN_DYE_SEA_URCHIN,
+                            CompressedFlags.BULLETIN_DYE_AMARANTH
+                        };
+                        Flags.Add(flag);
+                    }
+                    {
+                        var flag = new List<BigInteger>
+                        {
+                            CompressedFlags.BULLETIN_DYE_RED_MUSHROOM,
+                            CompressedFlags.BULLETIN_DYE_BEET
+                        };
+                        Flags.Add(flag);
+                    }
+                    break;
+                case "Field Research":
+                    BaseFlag = CompressedFlags.BULLETIN_FIELD_RESEARCH;
+                    break;
+                case "Fodder":
+                    BaseFlag = CompressedFlags.BULLETIN_FODDER;
+                    break;
+                case "Enchanter's":
+                    BaseFlag = CompressedFlags.BULLETIN_ENCHANTER;
+                    break;
+                case "Children's":
+                    BaseFlag = CompressedFlags.BULLETIN_CHILDREN;
+                    break;
+                case "Forager's":
+                    BaseFlag = CompressedFlags.BULLETIN_FORAGER;
+                    break;
+                case "Home Cook's":
+                    BaseFlag = CompressedFlags.BULLETIN_HOME_COOK;
+                    break;
+                case "Helper's":
+                    BaseFlag = CompressedFlags.BULLETIN_HELPERS;
+                    break;
+                case "Spirit's Eve":
+                    BaseFlag = CompressedFlags.BULLETIN_SPIRITS_EVE;
+                    break;
+                case "Winter Star":
+                    BaseFlag = CompressedFlags.BULLETIN_WINTER_STAR;
+                    break;
+
+            }
+        }
+    }
+
+}
+

--- a/Bundles/Bundes1_6/CompBundleSetData1_6.cs
+++ b/Bundles/Bundes1_6/CompBundleSetData1_6.cs
@@ -1,0 +1,20 @@
+﻿// Compressed version of BundleSetData
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SeedFinding.Bundles;
+
+namespace SeedFinding.Bundles1_6
+{
+    public class CompBundleSetData
+    {
+        public List<CompBundleData> Bundles;
+        public CompBundleSetData(BundleSetData bundleSetData)
+        {
+            Bundles = new List<CompBundleData>(
+                bundleSetData.Bundles.Select(o => new CompBundleData(o))
+                );
+        }
+    }
+}
+

--- a/Bundles/Bundes1_6/CompRandomBundleData1_6.cs
+++ b/Bundles/Bundes1_6/CompRandomBundleData1_6.cs
@@ -1,0 +1,29 @@
+﻿// Compressed version of RandomBundleData for use in generator
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SeedFinding.Bundles1_6
+{
+    public class CompRandomBundleData
+    {
+        public string AreaName;
+        public int[] Keys;
+        public List<CompBundleSetData> BundleSets;
+        public List<CompBundleData> Bundles;
+
+        public CompRandomBundleData(RandomBundleData randomBundleData)
+        {
+            AreaName = randomBundleData.AreaName;
+
+            Keys = randomBundleData.Keys.Trim().Split(' ').Select(o => int.Parse(o)).ToArray();
+            BundleSets = new List<CompBundleSetData>(
+                randomBundleData.BundleSets.Select(o => new CompBundleSetData(o))
+                );
+            Bundles = new List<CompBundleData>(
+                randomBundleData.Bundles.Select(o => new CompBundleData(o))
+                );
+        }
+    }
+}
+

--- a/Bundles/Bundes1_6/CompressedFlags1_6.cs
+++ b/Bundles/Bundes1_6/CompressedFlags1_6.cs
@@ -1,0 +1,145 @@
+﻿/* 
+ * bit mask used for defining bundle configurations
+ * 
+ * These are initiated in order, each one corresponding to the next bit in a BigInteger which is as large as necessary
+ * 
+ * You can define a specific state you're interested in searching for by
+ * ORing these flags together, for example
+ * 
+ * BigInteger searchState = (
+ *  CRAFTS_CONSTRUCTION |
+ *  BOILER_ENGINEER
+ * )
+ * 
+ * will limit your seed search to those that have the construction bundle and the engineer bundle.
+ */
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using SeedFinding.Bundles;
+
+namespace SeedFinding.Bundles1_6
+{
+    public class CompressedFlags
+    {
+        static CompressedFlags()
+        {
+            BigInteger flag = new BigInteger();
+            FieldInfo[] Flags = typeof(CompressedFlags).GetFields();
+            for (int i = 0; i < Flags.Length; i++)
+            {
+                Flags[i].SetValue(flag, (BigInteger)0b1 << i);
+                //Console.WriteLine(Flags[i].Name + " " + Flags[i].GetValue(flag).ToString());
+            }
+        }
+
+        public static BigInteger 
+
+        //Crafts Room
+
+            //Spring Forage Selection
+                CRAFTS_SPRING_FORAGE_WILD_HORSERADISH,
+                CRAFTS_SPRING_FORAGE_DAFFODIL,
+                CRAFTS_SPRING_FORAGE_LEEK,
+                CRAFTS_SPRING_FORAGE_DANDELION,
+                CRAFTS_SPRING_FORAGE_SPRING_ONION,
+
+            //Winter Forage Selection
+                CRAFTS_WINTER_FORAGE_WINTER_ROOT,
+                CRAFTS_WINTER_FORAGE_CRYSTAL_FRUIT,
+                CRAFTS_WINTER_FORAGE_SNOW_YAM,
+                CRAFTS_WINTER_FORAGE_CROCUS,
+                CRAFTS_WINTER_FORAGE_HOLLY,
+
+            CRAFTS_CONSTRUCTION, CRAFTS_STICKY, CRAFTS_FOREST,
+
+            //Forest Selection
+                CRAFTS_FOREST_MOSS,
+                CRAFTS_FOREST_FIBER,
+                CRAFTS_FOREST_ACORN,
+                CRAFTS_FOREST_MAPLE_SEED,
+
+            CRAFTS_EXOTIC, CRAFTS_WILD_MEDICINE,
+            
+        //Pantry
+            
+            //Spring Crops Selection
+                PANTRY_SPRING_CROPS_PARSNIP,
+                PANTRY_SPRING_CROPS_GREEN_BEAN,
+                PANTRY_SPRING_CROPS_CAULIFLOWER,
+                PANTRY_SPRING_CROPS_POTATO,
+                PANTRY_SPRING_CROPS_KALE,
+                PANTRY_SPRING_CROPS_CARROT,
+
+            //Summer Crops Selection
+                PANTRY_SUMMER_CROPS_TOMATO,
+                PANTRY_SUMMER_CROPS_HOT_PEPPER,
+                PANTRY_SUMMER_CROPS_BLUEBERRY,
+                PANTRY_SUMMER_CROPS_MELON,
+                PANTRY_SUMMER_CROPS_SUMMER_SQUASH,
+
+            //Fall Crops Selection
+                PANTRY_FALL_CROPS_CORN,
+                PANTRY_FALL_CROPS_EGGPLANT,
+                PANTRY_FALL_CROPS_PUMPKIN,
+                PANTRY_FALL_CROPS_YAM,
+                PANTRY_FALL_CROPS_BROCCOLI,
+
+            PANTRY_QUALITY, PANTRY_RARE,
+
+            //Quality Crops Selection
+                PANTRY_QUALITY_PARSNIP, PANTRY_QUALITY_GREEN_BEAN, PANTRY_QUALITY_POTATO, PANTRY_QUALITY_CAULIFLOWER,
+                PANTRY_QUALITY_MELON, PANTRY_QUALITY_BLUEBERRY, PANTRY_QUALITY_HOT_PEPPER,
+                PANTRY_QUALITY_PUMPKIN, PANTRY_QUALITY_YAM, PANTRY_QUALITY_EGGPLANT,
+
+            PANTRY_ANIMAL, PANTRY_FISH_FARMER, PANTRY_GARDEN,
+
+            PANTRY_ARTISAN, PANTRY_BREWER,
+
+        //Fish Tank
+
+            FISH_SPECIALITY, FISH_QUALITY, FISH_MASTER,
+
+        //Boiler Room
+
+            BOILER_BLACKSMITH,
+            BOILER_GEOLOGIST,
+            BOILER_ADVENTURER,
+            BOILER_TREASURE_HUNTER,
+            BOILER_ENGINEER,
+
+            //Adventurer selection
+                BOILER_ADVENTURER_SLIME,
+                BOILER_ADVENTURER_BAT_WING,
+                BOILER_ADVENTURER_SOLAR_ESSENCE,
+                BOILER_ADVENTURER_VOID_ESSENCE,
+                BOILER_ADVENTURER_BONE_FRAGMENTS,
+
+        //Bulletin Board
+
+            BULLETIN_CHEF,
+            BULLETIN_DYE,
+            BULLETIN_FIELD_RESEARCH,
+            BULLETIN_FODDER,
+            BULLETIN_ENCHANTER,
+            BULLETIN_CHILDREN,
+            BULLETIN_FORAGER,
+            BULLETIN_HOME_COOK,
+            BULLETIN_HELPERS,
+            BULLETIN_SPIRITS_EVE,
+            BULLETIN_WINTER_STAR,
+
+            //Dye selection
+                BULLETIN_DYE_RED_MUSHROOM, BULLETIN_DYE_BEET,
+                BULLETIN_DYE_SEA_URCHIN, BULLETIN_DYE_AMARANTH,
+                BULLETIN_DYE_SUNFLOWER,  BULLETIN_DYE_STARFRUIT,
+                BULLETIN_DYE_DUCK_FEATHER, BULLETIN_DYE_CACTUS_FRUIT,
+                BULLETIN_DYE_AQUAMARINE, BULLETIN_DYE_BLUEBERRY,
+                BULLETIN_DYE_RED_CABBAGE, BULLETIN_DYE_IRIDIUM_BAR;
+
+    }
+
+}
+

--- a/Bundles/Bundes1_6/CompressedRandomBundles1_6.cs
+++ b/Bundles/Bundes1_6/CompressedRandomBundles1_6.cs
@@ -1,0 +1,43 @@
+﻿// Class used to translate 64 bit mask to bundle item ids
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Reflection;
+
+namespace SeedFinding.Bundles1_6
+{
+    public class CompressedRemixBundles
+    {
+        public BigInteger State;
+        public CompressedRemixBundles(BigInteger state) { State = state; }
+
+        public bool Satisfies(BigInteger requirement)
+        {
+            return (requirement & State) == requirement;
+        }
+
+        public bool Contains(BigInteger requirement)
+        {
+            return (requirement & State) != 0;
+        }
+
+        public List<string> Curate()
+        {
+            List<string> result = new List<string>();
+            BigInteger flag = new BigInteger();
+            FieldInfo[] Flags = typeof(CompressedFlags).GetFields();
+            for (int i = 0; i < Flags.Length; i++)
+            {
+                if (this.Contains((BigInteger)Flags[i].GetValue(flag)))
+                {
+                    result.Add(Flags[i].Name);
+                }
+            }
+            return result;
+        }
+
+        //Removed toDict() as it is not yet updated to 1.6
+
+    }
+}
+

--- a/Bundles/Bundes1_6/README1_6.md
+++ b/Bundles/Bundes1_6/README1_6.md
@@ -1,0 +1,118 @@
+﻿# Remixed Bundles
+
+Two implementations exist here:
+
+1. `BundleGenerator.Generate(int seed)` - the debug generator, basically a clone of SDV's implementation with some reduced ops/cutting extra stuff to speed things up. This will return a similar structured result to the existing python bundle scripts. It's a bit slower, and it's a bit slower to test if it satifies your requirements.
+
+2. `RemixedBundles.Generate(int seed)` - the faster generator, this computes a bitmask representation of the complete bundle state that makes checking if your requirements are satisfied significantly easier.
+
+The basis for this is the `CompressedFlags` field, which is a mask of all the different fields you could have in a bundle (full listing is below and visible in `CompressedFlags.cs`). The `CompressedRemixBundles` class is a wrapper around the generated bitmask that provides some helper methods for checking if a bundle satisfies your requirements and backing out the original dictionary representation of the bundles.
+
+An example method to check if a bundle satisfies your requirements is as follows:
+
+```cs
+BigInteger DesiredBundles = (
+    CompressedFlags.CRAFTS_CONSTRUCTION |
+    CompressedFlags.CRAFTS_EXOTIC |
+    CompressedFlags.PANTRY_RARE |
+    CompressedFlags.FISH_QUALITY
+);
+bool valid = RemixedBundles.Generate(int seed).Satisfies(DesiredBundles);
+
+```
+
+## Crafts Room Choices
+
+### Spring Forage Selection (set at most 4, if you only care about specific ones, only set those flags)
+* `CRAFTS_SPRING_FORAGE_WILD_HORSERADISH`
+* `CRAFTS_SPRING_FORAGE_DAFFODIL`
+* `CRAFTS_SPRING_FORAGE_LEEK`
+* `CRAFTS_SPRING_FORAGE_DANDELION`
+* `CRAFTS_SPRING_FORAGE_SPRING_ONION`
+
+### Winter Forage Selection (set at most 4, if you only care about specific ones, only set those flags)
+* `CRAFTS_WINTER_FORAGE_WINTER_ROOT`
+* `CRAFTS_WINTER_FORAGE_CRYSTAL_FRUIT`
+* `CRAFTS_WINTER_FORAGE_SNOW_YAM`
+* `CRAFTS_WINTER_FORAGE_CROCUS`
+* `CRAFTS_WINTER_FORAGE_HOLLY`
+
+* `CRAFTS_CONSTRUCTION` or `CRAFTS_STICKY` or `CRAFTS_FOREST`
+
+### Forest Selection (set at most 3, if you only care about specific ones, only set those flags)
+* `CRAFTS_FOREST_MOSS`
+* `CRAFTS_FOREST_FIBER`
+* `CRAFTS_FOREST_ACORN`
+* `CRAFTS_FOREST_MAPLE_SEED`
+
+* `CRAFTS_EXOTIC` or `CRAFTS_WILD_MEDICINE`
+
+## Pantry Choices
+
+### Pantry Crops Selection (set at most 4, if you only care about specific ones, only set those flags)
+* `PANTRY_SPRING_CROPS_PARSNIP`
+* `PANTRY_SPRING_CROPS_GREEN_BEAN`
+* `PANTRY_SPRING_CROPS_CAULIFLOWER`
+* `PANTRY_SPRING_CROPS_POTATO`
+* `PANTRY_SPRING_CROPS_KALE`
+* `PANTRY_SPRING_CROPS_CARROT`
+
+* `PANTRY_SUMMER_CROPS_TOMATO`
+* `PANTRY_SUMMER_CROPS_HOT_PEPPER`
+* `PANTRY_SUMMER_CROPS_BLUEBERRY`
+* `PANTRY_SUMMER_CROPS_MELON`
+* `PANTRY_SUMMER_CROPS_SUMMER_SQUASH`
+
+* `PANTRY_FALL_CROPS_CORN`
+* `PANTRY_FALL_CROPS_EGGPLANT`
+* `PANTRY_FALL_CROPS_PUMPKIN`
+* `PANTRY_FALL_CROPS_YAM`
+* `PANTRY_FALL_CROPS_BROCCOLI`
+
+* `PANTRY_QUALITY` or `PANTRY_RARE`
+
+### Quality Specific flags (dont set these if you don't choose the Quality bundle, if you don't care between the options, don't set either flag)
+* `PANTRY_QUALITY_PARSNIP` or `PANTRY_QUALITY_GREEN_BEAN` or `PANTRY_QUALITY_POTATO` or `PANTRY_QUALITY_CAULIFLOWER`
+* `PANTRY_QUALITY_MELON` or `PANTRY_QUALITY_BLUEBERRY` or `PANTRY_QUALITY_HOT_PEPPER`
+* `PANTRY_QUALITY_PUMPKIN` or `PANTRY_QUALITY_YAM` or `PANTRY_QUALITY_EGGPLANT`
+
+* `PANTRY_ANIMAL` or `PANTRY_FISH_FARMER` or `PANTRY_GARDEN`
+* `PANTRY_ARTISAN` or `PANTRY_BREWER`
+
+## Fish Tank Choices
+* `FISH_SPECIALITY` or `FISH_QUALITY` or `FISH_MASTER`
+
+## Boiler Room Choices (set at most 3)
+* `BOILER_BLACKSMITH`
+* `BOILER_GEOLOGIST`
+* `BOILER_ADVENTURER`
+* `BOILER_TREASURE_HUNTER`
+* `BOILER_ENGINEER`
+
+### Adventurer Specific flags (only set if you choose the Adventurer bundle, set at most 4)
+* `BOILER_ADVENTURER_SLIME`
+* `BOILER_ADVENTURER_BAT_WING`
+* `BOILER_ADVENTURER_SOLAR_ESSENCE`
+* `BOILER_ADVENTURER_VOID_ESSENCE`
+* `BOILER_ADVENTURER_BONE_FRAGMENTS`
+
+## Bulletin Board Choices (set at most 5)
+* `BULLETIN_CHEF`
+* `BULLETIN_DYE`
+* `BULLETIN_FIELD_RESEARCH`
+* `BULLETIN_FODDER`
+* `BULLETIN_ENCHANTER`
+* `BULLETIN_CHILDREN`
+* `BULLETIN_FORAGER`
+* `BULLETIN_HOME_COOK`
+* `BULLETIN_HELPERS`
+* `BULLETIN_SPIRITS_EVE`
+* `BULLETIN_WINTER_STAR`
+
+### Dye Specific flags (only set if you choose the Dye bundle, if you don't care between the options, don't set either flag)
+* `BULLETIN_DYE_RED_MUSHROOM` or `BULLETIN_DYE_BEET`
+* `BULLETIN_DYE_SEA_URCHIN` or `BULLETIN_DYE_AMARANTH`
+* `BULLETIN_DYE_SUNFLOWER` or `BULLETIN_DYE_STARFRUIT`
+* `BULLETIN_DYE_DUCK_FEATHER` or `BULLETIN_DYE_CACTUS_FRUIT`
+* `BULLETIN_DYE_AQUAMARINE` or `BULLETIN_DYE_BLUEBERRY`
+* `BULLETIN_DYE_RED_CABBAGE` or `BULLETIN_DYE_IRIDIUM_BAR`

--- a/Bundles/Bundes1_6/RandomBundleData1_6.cs
+++ b/Bundles/Bundes1_6/RandomBundleData1_6.cs
@@ -1,0 +1,16 @@
+﻿// clone of SDV's RandomBundleData object
+using System;
+using System.Collections.Generic;
+using SeedFinding.Bundles;
+
+namespace SeedFinding.Bundles1_6
+{
+	public class RandomBundleData
+    {
+        public string AreaName = "";
+        public string Keys = "";
+        public List<BundleSetData> BundleSets = new List<BundleSetData>();
+        public List<BundleData> Bundles = new List<BundleData>();
+    }
+}
+

--- a/Bundles/Bundes1_6/RemixedBundles1_6.cs
+++ b/Bundles/Bundes1_6/RemixedBundles1_6.cs
@@ -1,0 +1,118 @@
+﻿// Generator class for Compressed Bundle Configurations
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using System.Numerics;
+
+namespace SeedFinding.Bundles1_6
+{
+    public class RemixedBundles
+    {
+        public static List<RandomBundleData> RandomBundles;
+        public static List<CompRandomBundleData> CompRandomBundles;
+
+        static RemixedBundles()
+		{
+            RandomBundles = JsonConvert.DeserializeObject<List<RandomBundleData>>(File.ReadAllText(@"data/RandomBundles1_6.json"));
+            CompRandomBundles = new List<CompRandomBundleData>(RandomBundles.Select(o => new CompRandomBundleData(o)));
+        }
+        public static CompressedRemixBundles Generate(int seed)
+        {
+            Random random = Utility.CreateRandom((double)seed * 9.0);
+            var result = new CompressedRemixBundles(0);
+            foreach (var area_data in CompRandomBundles)
+            {
+                Dictionary<int, CompBundleData> selected_bundles = new Dictionary<int, CompBundleData>();
+                CompBundleSetData bundle_set = random.ChooseFrom(area_data.BundleSets);
+                if (bundle_set != null)
+                {
+                    foreach (CompBundleData bundle_data4 in bundle_set.Bundles)
+                    {
+                        selected_bundles[bundle_data4.Index] = bundle_data4;
+                    }
+                }
+                List<CompBundleData> random_bundle_pool = new List<CompBundleData>(area_data.Bundles);
+                for (int i = 0; i < area_data.Keys.Length; i++)
+                {
+                    if (selected_bundles.ContainsKey(i))
+                    {
+                        continue;
+                    }
+                    List<CompBundleData> index_bundles = new List<CompBundleData>();
+                    foreach (var data in random_bundle_pool)
+                    {
+                        if (data.Index == i)
+                        {
+                            index_bundles.Add(data);
+                        }
+                    }
+                    if (index_bundles.Count > 0)
+                    {
+                        CompBundleData selected_bundle = random.ChooseFrom(index_bundles);
+                        random_bundle_pool.Remove(selected_bundle);
+                        selected_bundles[i] = selected_bundle;
+                        continue;
+                    }
+                    foreach (CompBundleData bundle_data in random_bundle_pool)
+                    {
+                        if (bundle_data.Index == -1)
+                        {
+                            index_bundles.Add(bundle_data);
+                        }
+                    }
+                    if(index_bundles.Count > 0)
+                    {
+                        CompBundleData selected_bundle2 = random.ChooseFrom(index_bundles);
+                        random_bundle_pool.Remove(selected_bundle2);
+                        selected_bundles[i] = selected_bundle2;
+                    }
+
+                }
+                foreach(int key in selected_bundles.Keys)
+                {
+                    CompBundleData data = selected_bundles[key];
+                    result.State |= data.BaseFlag;
+                    // handle random flags
+                    List<BigInteger> flags = new List<BigInteger>();
+                    if (data.HasRandom)
+                    {
+                        foreach (var flag in data.Flags)
+                        {
+                            flags.Add(random.ChooseFrom(flag));
+                        }
+                        flags.Reverse();
+                    }
+                    else
+                    {
+                        if (data.Flags.Count > 0)
+                        {
+                            flags.AddRange(data.Flags[0]);
+                        }
+                    }
+                    // down select
+                    int pick_count = data.Pick;
+                    int require_items = data.RequiredItems;
+                    if (pick_count < 0) pick_count = flags.Count;
+                    if (require_items < 0) require_items = pick_count;
+                    while (flags.Count > pick_count)
+                    {
+                        int index = random.Next(flags.Count);
+                        flags.RemoveAt(index);
+                    }
+                    // set the flags
+                    foreach(var flag in flags)
+                    {
+                        result.State |= flag;
+                    }
+                }
+            }
+            return result;
+        }
+	}
+
+    
+}
+

--- a/Bundles/CompressedRandomBundles.cs
+++ b/Bundles/CompressedRandomBundles.cs
@@ -1,6 +1,7 @@
 ﻿// Class used to translate 64 bit mask to bundle item ids
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace SeedFinding.Bundles
 {
@@ -12,6 +13,11 @@ namespace SeedFinding.Bundles
         public bool Satisfies(ulong requirement)
         {
             return (requirement & State) == requirement;
+        }
+
+        public bool Contains(ulong requirement)
+        {
+            return (requirement & State) != 0;
         }
 
         public Dictionary<string, List<int>> ToDict()

--- a/Program.cs
+++ b/Program.cs
@@ -26,6 +26,9 @@ namespace SeedFinding
             // the optimal size for this will vary depending on your system
             int blockSize = 1 << 16;
 
+            // run a search for specific remux bundle set in 1.6
+            bool runRemixSearch1_6 = true;
+
             // run a search for a specific remix bundle set
             bool runRemixSearch = false;
 
@@ -35,51 +38,18 @@ namespace SeedFinding
             // search for a TAS vault seed that is just cart based
             bool runCartSearch = false;
 
+            //
+            bool runBoilerSearch = false;
+
             // Quick and dirty call to specific searches.  Adjust this as needed for your searches.
             if (true)
             {
 
-                Game1.UseLegacyRandom = true;
-
-
-                
-
-                //Console.WriteLine(String.Join(",",new List<string>(TravelingCart.GetStock(359003761, 5).Select(o=>Item.Get(o.Id).Name))));
-                //Console.WriteLine(String.Join(",", Trash1_6.Trash.getAllTrash(48462440, 12, 0.1)));
-                //Console.WriteLine(Trash1_6.Trash.getTrash(48462440, 12, Trash1_6.Trash.Can.George, -0.054).ToString());
-                //return;
-                /*foreach(var item in TravelingCart.GetStockNew(168, 5))
-                {
-                    Console.WriteLine(item.ToString());
-                }
-                return;*/
-                // Console.WriteLine(String.Join(",",new List<string>(TravelingCart.GetStock(184400, 5).Select(o=>Item.Get(o.Id).Name))));
-                // return;
-
-                //BoilerRoomClassic.ValidSeed(9110854);
-                //return;
-
-                //FileStream fs = new FileStream("BoilerRoom.txt", FileMode.Create);
-                // First, save the standard output.
-                //TextWriter tmp = Console.Out;
-                //StreamWriter sw = new StreamWriter(fs);
-                //Console.SetOut(sw);
-                int numSeeds = Int32.MaxValue;
-                double time = BoilerRoomClassic.Search(-1 + 1, numSeeds, blockSize, out List<int> validSeeds);
-                foreach (var item in validSeeds)
-                {
-                    Console.WriteLine(item);
-                }
-                Console.WriteLine($"Total Time: {time} (sps: {numSeeds / time})");
-               // Console.SetOut(tmp);
-               // sw.Close();
             }
-            return;
 
-
-            Console.WriteLine($"Start: {DateTime.Now}");
             if (runSpeedTest)
             {
+                Console.WriteLine($"Start: {DateTime.Now}");
                 int numSeeds = 1 << 24;
                 Console.WriteLine($"Estimating Remix Bundle Speed using {numSeeds} seeds");
                 double time = RemixSeeding.Search(numSeeds, blockSize, out var _);
@@ -90,6 +60,19 @@ namespace SeedFinding
                 time = VaultCartSeeding.Search(numSeeds, blockSize, out var _);
                 Console.WriteLine($"Total Time: {time} (sps: {numSeeds / time})");
                 Console.WriteLine($"Estimated +int32 Scan Time: {(Int32.MaxValue / (float)numSeeds) * time}");
+            }
+
+            if (runRemixSearch1_6)
+            {
+                bool curate = true;
+                Game1.UseLegacyRandom = true;
+                List<int> validSeeds = new List<int>();
+                RemixCC.Search(100000, 1 << 16, out validSeeds, curate);
+                foreach (int seed in validSeeds)
+                {
+                    File.AppendAllText("RemixCC1_6.txt", seed.ToString() + Environment.NewLine);
+                }
+                return;
             }
 
             if (runRemixSearch)
@@ -124,6 +107,44 @@ namespace SeedFinding
                 double time = VaultCartSeeding.Search(numSeeds, blockSize, out List<int> validSeeds);
                 Console.WriteLine($"Total Time: {time} (sps: {numSeeds / time})");
             }
+
+            if (runBoilerSearch)
+            {
+
+                Game1.UseLegacyRandom = true;
+
+                //Console.WriteLine(String.Join(",",new List<string>(TravelingCart.GetStock(359003761, 5).Select(o=>Item.Get(o.Id).Name))));
+                //Console.WriteLine(String.Join(",", Trash1_6.Trash.getAllTrash(48462440, 12, 0.1)));
+                //Console.WriteLine(Trash1_6.Trash.getTrash(48462440, 12, Trash1_6.Trash.Can.George, -0.054).ToString());
+                //return;
+                /*foreach(var item in TravelingCart.GetStockNew(168, 5))
+                {
+                    Console.WriteLine(item.ToString());
+                }
+                return;*/
+                // Console.WriteLine(String.Join(",",new List<string>(TravelingCart.GetStock(184400, 5).Select(o=>Item.Get(o.Id).Name))));
+                // return;
+
+                //BoilerRoomClassic.ValidSeed(9110854);
+                //return;
+
+                //FileStream fs = new FileStream("BoilerRoom.txt", FileMode.Create);
+                // First, save the standard output.
+                //TextWriter tmp = Console.Out;
+                //StreamWriter sw = new StreamWriter(fs);
+                //Console.SetOut(sw);
+                int numSeeds = Int32.MaxValue;
+                double time = BoilerRoomClassic.Search(-1 + 1, numSeeds, blockSize, out List<int> validSeeds);
+                foreach (var item in validSeeds)
+                {
+                    Console.WriteLine(item);
+                }
+                Console.WriteLine($"Total Time: {time} (sps: {numSeeds / time})");
+                // Console.SetOut(tmp);
+                // sw.Close();
+            }
+
+            return;
 
         }
     }

--- a/RemixCC.cs
+++ b/RemixCC.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using SeedFinding.Bundles1_6;
+using SeedFinding.Cart;
+using SeedFinding.Locations;
+using SeedFinding.Trash;
+using System.Numerics;
+
+namespace SeedFinding
+{
+    public class RemixCC
+    {
+        public static BigInteger requiredBundles = (
+                CompressedFlags.CRAFTS_FOREST |
+                CompressedFlags.CRAFTS_WILD_MEDICINE |
+                CompressedFlags.PANTRY_GARDEN |
+                CompressedFlags.PANTRY_RARE |
+                CompressedFlags.PANTRY_BREWER |
+                CompressedFlags.BULLETIN_FORAGER
+            );
+
+        public static BigInteger KillerBundles = (
+                CompressedFlags.BULLETIN_CHEF |
+                CompressedFlags.BULLETIN_ENCHANTER |
+                CompressedFlags.BULLETIN_HOME_COOK |
+                CompressedFlags.BULLETIN_DYE_DUCK_FEATHER
+            );
+
+        static bool ValidSeed(int gameId, bool curate)
+        {
+
+            var bundles = RemixedBundles.Generate(gameId);
+            if (bundles.Contains(KillerBundles))
+            {
+                return false;
+            }
+            if(!bundles.Satisfies(requiredBundles))
+            {
+                return false;
+            }
+            if (curate)
+            {
+                var bundle = string.Join(", \n", bundles.Curate().ToArray());
+                Console.WriteLine($"Seed: {gameId}{Environment.NewLine}Bundle Flags:{Environment.NewLine}{bundle}");
+            }
+            return true;
+        }
+
+        // parallel search
+        public static double Search(int numSeeds, int blockSize, out List<int> validSeeds, bool curate)
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            var bag = new ConcurrentBag<int>();
+            var partioner = Partitioner.Create(0, numSeeds, blockSize);
+            Parallel.ForEach(partioner, (range, loopState) =>
+            {
+                for (int seed = range.Item1; seed < range.Item2; seed++)
+                {
+                    if (ValidSeed(seed, curate))
+                    {
+                        bag.Add(seed);
+                        if (!curate)
+                        {
+                            Console.WriteLine(seed);
+                        }
+                        
+                    }
+                }
+            });
+            double seconds = stopwatch.Elapsed.TotalSeconds;
+            Console.WriteLine($"Found: {bag.Count} sols in {seconds.ToString("F2")} s");
+            validSeeds = bag.ToList();
+            validSeeds.Sort();
+            return seconds;
+        }
+    }
+}
+
+

--- a/SeedFinding.csproj
+++ b/SeedFinding.csproj
@@ -55,5 +55,8 @@
     <None Update="data\object_info.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="data\RandomBundles1_6.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/data/RandomBundles1_6.json
+++ b/data/RandomBundles1_6.json
@@ -1,0 +1,533 @@
+[
+    {
+        "Id": "Crafts Room",
+        "AreaName": "Crafts Room",
+        "Keys": "13 14 15 16 17 19",
+        "BundleSets": [
+            {
+                "Id": "Default",
+                "Bundles": [
+                    {
+                        "Id": "Spring Foraging",
+                        "Name": "Spring Foraging",
+                        "Index": 0,
+                        "Sprite": "13",
+                        "Color": "Green",
+                        "Items": "1 Wild Horseradish, 1 Daffodil, 1 Leek, 1 Dandelion, 1 Spring Onion",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "30 Spring Seeds"
+                    },
+                    {
+                        "Id": "Summer Foraging",
+                        "Name": "Summer Foraging",
+                        "Index": 1,
+                        "Sprite": "14",
+                        "Color": "Yellow",
+                        "Items": "1 Grape, 1 Spice Berry, 1 Sweet Pea",
+                        "Pick": 3,
+                        "RequiredItems": -1,
+                        "Reward": "30 Summer Seeds"
+                    },
+                    {
+                        "Id": "Fall Foraging",
+                        "Name": "Fall Foraging",
+                        "Index": 2,
+                        "Sprite": "15",
+                        "Color": "Orange",
+                        "Items": "1 Common Mushroom, 1 Wild Plum, 1 Hazelnut, 1 Blackberry",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "30 Fall Seeds"
+                    },
+                    {
+                        "Id": "Winter Foraging",
+                        "Name": "Winter Foraging",
+                        "Index": 3,
+                        "Sprite": "16",
+                        "Color": "Teal",
+                        "Items": "1 Winter Root, 1 Crystal Fruit, 1 Snow Yam, 1 Crocus, 1 Holly",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "30 Winter Seeds"
+                    }
+                ]
+            }
+        ],
+        "Bundles": [
+            {
+                "Id": "Construction",
+                "Name": "Construction",
+                "Index": 4,
+                "Sprite": "17",
+                "Color": "Red",
+                "Items": "99 Wood, 99 Wood, 99 Stone, 10 Hardwood",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Charcoal Kiln"
+            },
+            {
+                "Id": "Sticky",
+                "Name": "Sticky",
+                "Index": 4,
+                "Sprite": "LooseSprites\\BundleSprites:10",
+                "Color": "Yellow",
+                "Items": "500 Sap",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Charcoal Kiln"
+            },
+            {
+                "Id": "Forest",
+                "Name": "Forest",
+                "Index": 4,
+                "Sprite": "LooseSprites\\BundleSprites:12",
+                "Color": "Green",
+                "Items": "10 Moss, 200 Fiber, 10 Acorn, 10 Maple Seed",
+                "Pick": 3,
+                "RequiredItems": -1,
+                "Reward": "1 Charcoal Kiln"
+            },
+            {
+                "Id": "Exotic Foraging",
+                "Name": "Exotic Foraging",
+                "Index": 5,
+                "Sprite": "19",
+                "Color": "Purple",
+                "Items": "1 Coconut, 1 Cactus Fruit, 1 Cave Carrot, 1 Red Mushroom, 1 Purple Mushroom, 1 Maple Syrup, 1 Oak Resin, 1 Pine Tar, 1 Morel",
+                "Pick": -1,
+                "RequiredItems": 5,
+                "Reward": "5 Autumn's Bounty"
+            },
+            {
+                "Id": "Wild Medicine",
+                "Name": "Wild Medicine",
+                "Index": 5,
+                "Sprite": "LooseSprites\\BundleSprites:9",
+                "Color": "Green",
+                "Items": "5 Purple Mushroom, 5 Fiddlehead Fern, 5 White Algae, 5 Hops",
+                "Pick": -1,
+                "RequiredItems": 3,
+                "Reward": "2 Cookout Kit"
+            }
+        ]
+    },
+    {
+        "Id": "Pantry",
+        "AreaName": "Pantry",
+        "Keys": "0 1 2 3 4 5",
+        "BundleSets": [
+            {
+                "Id": "Default",
+                "Bundles": [
+                    {
+                        "Id": "Spring Crops",
+                        "Name": "Spring Crops",
+                        "Index": 0,
+                        "Sprite": "0",
+                        "Color": "Green",
+                        "Items": "1 Parsnip, 1 Green Bean, 1 Cauliflower, 1 Potato, 1 Kale, 1 Carrot",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "20 Speed-Gro"
+                    },
+                    {
+                        "Id": "Summer Crops",
+                        "Name": "Summer Crops",
+                        "Index": 1,
+                        "Sprite": "1",
+                        "Color": "Yellow",
+                        "Items": "1 Tomato, 1 Hot Pepper, 1 Blueberry, 1 Melon, 1 Summer Squash",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "1 Quality Sprinkler"
+                    },
+                    {
+                        "Id": "Fall Crops",
+                        "Name": "Fall Crops",
+                        "Index": 2,
+                        "Sprite": "2",
+                        "Color": "Orange",
+                        "Items": "1 Corn, 1 Eggplant, 1 Pumpkin, 1 Yam, 1 Broccoli",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "1 Bee House"
+                    }
+                ]
+            }
+        ],
+        "Bundles": [
+            {
+                "Id": "Quality Crops",
+                "Name": "Quality Crops",
+                "Index": 3,
+                "Sprite": "3",
+                "Color": "Teal",
+                "Items": "[5 GQ Parsnip|5 GQ Green Bean|5 GQ Cauliflower|5 GQ Potato], [5 GQ Melon|5 GQ Hot Pepper|5 GQ Blueberry], [5 GQ Pumpkin|5 GQ Eggplant|5 GQ Yam], [5 GQ Corn]",
+                "Pick": -1,
+                "RequiredItems": 3,
+                "Reward": "1 Preserves Jar"
+            },
+            {
+                "Id": "Rare Crops",
+                "Name": "Rare Crops",
+                "Index": 3,
+                "Sprite": "LooseSprites\\BundleSprites:3",
+                "Color": "Teal",
+                "Items": "1 Ancient Fruit, 1 Sweet Gem Berry",
+                "Pick": -1,
+                "RequiredItems": 1,
+                "Reward": "1 Preserves Jar"
+            },
+            {
+                "Id": "Animal",
+                "Name": "Animal",
+                "Index": 4,
+                "Sprite": "4",
+                "Color": "Red",
+                "Items": "1 Large Milk, 1 182, 1 174, 1 L. Goat Milk, 1 Wool, 1 Duck Egg ",
+                "Pick": -1,
+                "RequiredItems": 5,
+                "Reward": "1 Cheese Press"
+            },
+            {
+                "Id": "Fish Farmer's",
+                "Name": "Fish Farmer's",
+                "Index": 4,
+                "Sprite": "LooseSprites\\BundleSprites:8",
+                "Color": "Blue",
+                "Items": "15 Roe, 15 Aged Roe, 1 Squid Ink",
+                "Pick": -1,
+                "RequiredItems": 2,
+                "Reward": "1 Worm Bin"
+            },
+            {
+                "Id": "Garden",
+                "Name": "Garden",
+                "Index": 4,
+                "Sprite": "LooseSprites\\BundleSprites:7",
+                "Color": "Red",
+                "Items": "1 Tulip, 1 Summer Spangle, 1 Fairy Rose, 1 Blue Jazz, 1 Sunflower",
+                "Pick": -1,
+                "RequiredItems": 4,
+                "Reward": "1 Quality Sprinkler"
+            },
+            {
+                "Id": "Artisan",
+                "Name": "Artisan",
+                "Index": 5,
+                "Sprite": "5",
+                "Color": "Purple",
+                "Items": "1 Truffle Oil, 1 Cloth, 1 Goat Cheese, 1 Cheese, 1 Honey, 1 Jelly, 1 Apple, 1 Apricot, 1 Orange, 1 Peach, 1 Pomegranate, 1 Cherry",
+                "Pick": -1,
+                "RequiredItems": 6,
+                "Reward": "1 Keg"
+            },
+            {
+                "Id": "Brewer's",
+                "Name": "Brewer's",
+                "Index": 5,
+                "Sprite": "LooseSprites\\BundleSprites:2",
+                "Color": "Orange",
+                "Items": "1 Mead, 1 Wine, 1 Juice, 1 Pale Ale, 1 Green Tea",
+                "Pick": -1,
+                "RequiredItems": 4,
+                "Reward": "1 Keg"
+            }
+        ]
+    },
+    {
+        "Id": "Fish Tank",
+        "AreaName": "Fish Tank",
+        "Keys": "6 7 8 9 10 11",
+        "BundleSets": [
+            {
+                "Id": "Default",
+                "Bundles": [
+                    {
+                        "Id": "River Fish",
+                        "Name": "River Fish",
+                        "Index": 0,
+                        "Sprite": "6",
+                        "Color": "Teal",
+                        "Items": "1 Sunfish, 1 Catfish, 1 Shad, 1 Tiger Trout",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "30 Deluxe Bait"
+                    },
+                    {
+                        "Id": "Lake Fish",
+                        "Name": "Lake Fish",
+                        "Index": 1,
+                        "Sprite": "7",
+                        "Color": "Green",
+                        "Items": "1 Largemouth Bass, 1 Carp, 1 Bullhead, 1 Sturgeon",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "1 Dressed Spinner"
+                    },
+                    {
+                        "Id": "Ocean Fish",
+                        "Name": "Ocean Fish",
+                        "Index": 2,
+                        "Sprite": "8",
+                        "Color": "Blue",
+                        "Items": "1 Sardine, 1 Tuna, 1 Red Snapper, 1 Tilapia",
+                        "Pick": 4,
+                        "RequiredItems": -1,
+                        "Reward": "5 Warp Totem: Beach"
+                    },
+                    {
+                        "Id": "Night Fishing",
+                        "Name": "Night Fishing",
+                        "Index": 3,
+                        "Sprite": "9",
+                        "Color": "Purple",
+                        "Items": "1 Walleye, 1 Bream, 1 Eel",
+                        "Pick": 3,
+                        "RequiredItems": -1,
+                        "Reward": "1 Glow Ring"
+                    }
+                ]
+            }
+        ],
+        "Bundles": [
+            {
+                "Id": "Crab Pot",
+                "Name": "Crab Pot",
+                "Index": 4,
+                "Sprite": "11",
+                "Color": "Purple",
+                "Items": "1 Lobster, 1 Crayfish, 1 Crab, 1 Cockle, 1 Mussel, 1 Shrimp, 1 Snail, 1 Periwinkle, 1 Oyster, 1 Clam",
+                "Pick": -1,
+                "RequiredItems": 5,
+                "Reward": "3 Crab Pot"
+            },
+            {
+                "Id": "Specialty Fish",
+                "Name": "Specialty Fish",
+                "Index": 5,
+                "Sprite": "10",
+                "Color": "Red",
+                "Items": "1 Pufferfish, 1 Ghostfish, 1 Sandfish, 1 Woodskip",
+                "Pick": -1,
+                "RequiredItems": 4,
+                "Reward": "5 Dish O' The Sea"
+            },
+            {
+                "Id": "Quality Fish",
+                "Name": "Quality Fish",
+                "Index": 5,
+                "Sprite": "LooseSprites\\BundleSprites:4",
+                "Color": "Red",
+                "Items": "1 GQ Largemouth Bass, 1 GQ Shad, 1 GQ Tuna, 1 GQ Walleye",
+                "Pick": -1,
+                "RequiredItems": 4,
+                "Reward": "5 Dish O' The Sea"
+            },
+            {
+                "Id": "Master Fisher's",
+                "Name": "Master Fisher's",
+                "Index": 5,
+                "Sprite": "12",
+                "Color": "Red",
+                "Items": "1 Lava Eel, 1 Scorpion Carp, 1 Octopus, 1 Blobfish",
+                "Pick": -1,
+                "RequiredItems": 2,
+                "Reward": "5 Dish O' The Sea"
+            }
+        ]
+    },
+    {
+        "Id": "Boiler Room",
+        "AreaName": "Boiler Room",
+        "Keys": "20 21 22",
+        "BundleSets": [],
+        "Bundles": [
+            {
+                "Id": "Blacksmith's",
+                "Name": "Blacksmith's",
+                "Index": -1,
+                "Sprite": "20",
+                "Color": "Orange",
+                "Items": "1 Copper Bar, 1 Iron Bar, 1 Gold Bar",
+                "Pick": -1,
+                "RequiredItems": 3,
+                "Reward": "1 Furnace"
+            },
+            {
+                "Id": "Geologist's",
+                "Name": "Geologist's",
+                "Index": -1,
+                "Sprite": "21",
+                "Color": "Purple",
+                "Items": "1 Quartz, 1 Earth Crystal, 1 Frozen Tear, 1 Fire Quartz",
+                "Pick": -1,
+                "RequiredItems": 4,
+                "Reward": "5 Omni Geode"
+            },
+            {
+                "Id": "Adventurer's",
+                "Name": "Adventurer's",
+                "Index": -1,
+                "Sprite": "22",
+                "Color": "Purple",
+                "Items": "99 Slime, 10 Bat Wing, 1 Solar Essence, 1 Void Essence, 10 Bone Fragment",
+                "Pick": 4,
+                "RequiredItems": 2,
+                "Reward": "1 Small Magnet Ring"
+            },
+            {
+                "Id": "Treasure Hunter's",
+                "Name": "Treasure Hunter's",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:1",
+                "Color": "Yellow",
+                "Items": "1 Amethyst, 1 Topaz, 1 Emerald, 1 Diamond, 1 Ruby, 1 Aquamarine",
+                "Pick": -1,
+                "RequiredItems": 5,
+                "Reward": "1 Lucky Lunch"
+            },
+            {
+                "Id": "Engineer's",
+                "Name": "Engineer's",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:11",
+                "Color": "Purple",
+                "Items": "1 Iridium Ore, 1 Battery, 5 Refined Quartz",
+                "Pick": -1,
+                "RequiredItems": 3,
+                "Reward": "2 Furnace"
+            }
+        ]
+    },
+    {
+        "Id": "Bulletin Board",
+        "AreaName": "Bulletin Board",
+        "Keys": "31 32 33 34 35",
+        "BundleSets": [],
+        "Bundles": [
+            {
+                "Id": "Chef's",
+                "Name": "Chef's",
+                "Index": -1,
+                "Sprite": "31",
+                "Color": "Red",
+                "Items": "1 Maple Syrup, 1 Fiddlehead Fern, 1 Truffle, 1 Poppy, 1 Maki Roll, 1 Fried Egg",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Pink Cake"
+            },
+            {
+                "Id": "Dye",
+                "Name": "Dye",
+                "Index": -1,
+                "Sprite": "34",
+                "Color": "Teal",
+                "Items": "[1 Red Mushroom|1 Beet], [1 Sea Urchin|1 Amaranth], [1 Sunflower|1 Starfruit], [1 Duck Feather|1 Cactus Fruit], [1 Aquamarine|1 Blueberry], [1 Red Cabbage|1 Iridium Bar]",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Seed Maker"
+            },
+            {
+                "Id": "Field Research",
+                "Name": "Field Research",
+                "Index": -1,
+                "Sprite": "32",
+                "Color": "Blue",
+                "Items": "1 Purple Mushroom, 1 Nautilus Shell, 1 Chub, 1 Frozen Geode",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Recycling Machine"
+            },
+            {
+                "Id": "Fodder",
+                "Name": "Fodder",
+                "Index": -1,
+                "Sprite": "35",
+                "Color": "Yellow",
+                "Items": "10 Wheat, 10 Hay, 3 Apple",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Heater"
+            },
+            {
+                "Id": "Enchanter's",
+                "Name": "Enchanter's",
+                "Index": -1,
+                "Sprite": "33",
+                "Color": "Purple",
+                "Items": "1 Oak Resin, 1 Wine, 1 Rabbit's Foot, 1 Pomegranate",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "5 Gold Bar"
+            },
+            {
+                "Id": "Children's",
+                "Name": "Children's",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:0",
+                "Color": "Green",
+                "Items": "1 Ancient Doll, 1 Ice Cream, 1 Cookie, 10 Salmonberry",
+                "Pick": -1,
+                "RequiredItems": 3,
+                "Reward": "3 Battery"
+            },
+            {
+                "Id": "Forager's",
+                "Name": "Forager's",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:5",
+                "Color": "Orange",
+                "Items": "50 Salmonberry, 50 Blackberry, 15 Wild Plum",
+                "Pick": -1,
+                "RequiredItems": 2,
+                "Reward": "3 Tapper"
+            },
+            {
+                "Id": "Home Cook's",
+                "Name": "Home Cook's",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:6",
+                "Color": "Yellow",
+                "Items": "10 EggCategory, 10 MilkCategory, 100 Wheat Flour",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "5 Complete Breakfast"
+            },
+            {
+                "Id": "Helper's",
+                "Name": "Helper's",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:13",
+                "Color": "Red",
+                "Items": "1 Prize Ticket, 5 Mystery Box",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "1 Stardrop Tea"
+            },
+            {
+                "Id": "Spirit's Eve",
+                "Name": "Spirit's Eve",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:19",
+                "Color": "Purple",
+                "Items": "1 Jack-O-Lantern, 10 Corn, 10 Bat Wing",
+                "Pick": -1,
+                "RequiredItems": -1,
+                "Reward": "5 Complete Breakfast"
+            },
+            {
+                "Id": "Winter Star",
+                "Name": "Winter Star",
+                "Index": -1,
+                "Sprite": "LooseSprites\\BundleSprites:20",
+                "Color": "Red",
+                "Items": "5 Holly, 1 Plum Pudding, 1 Stuffing, 5 Powdermelon",
+                "Pick": -1,
+                "RequiredItems": 2,
+                "Reward": "3 Mystery Box"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Added RemixCC.cs to perform parallel searches over the 1.6 seedspace

Added a new namespace SeedFinding.Bundles1_6

This ensures 1.5 seed searching is unaffected, perhaps we can merge the namespaces in the future.

Added RandomBundles1_6.json

Redesigned multiple files:
README1_6.md
CompBundleData1_6.cs
CompressedFlags1_6.cs

Bundles1_6.CompressedFlags now use BigInteger for futureproofing and flexibility

Added Contains() method to CompressedRemixBundles for more robust flag checking